### PR TITLE
add content parameter to monit::check

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -10,6 +10,12 @@
 #
 # [*source*]
 #   Path of the configuration file.
+#   Exclusive with the `content` parameter.
+#   Default: undef
+#
+# [*content*]
+#   Content of the configuration file.
+#   Exclusive with the `source` parameter.
 #   Default: undef
 #
 # [*package_name*]
@@ -39,6 +45,7 @@
 define monit::check (
   $ensure       = present,
   $source       = undef,
+  $content      = undef,
   $package_name = 'monit',
   $service_name = 'monit',
 ) {
@@ -48,9 +55,18 @@ define monit::check (
     "${ensure} is not supported for ensure. \
 Allowed values are 'present' and 'absent'."
   )
-  validate_string($source)
   validate_string($package_name)
   validate_string($service_name)
+
+  if $source and $content {
+    fail 'Parameters source and content are mutually exclusive'
+  }
+  if $source {
+    validate_string($source)
+  }
+  if $content {
+    validate_string($content)
+  }
 
   file { "/etc/monit/conf.d/${name}":
     ensure  => $ensure,
@@ -58,6 +74,7 @@ Allowed values are 'present' and 'absent'."
     group   => 0,
     mode    => '0644',
     source  => $source,
+    content => $content,
     notify  => Service[$service_name],
     require => Package[$package_name],
   }

--- a/tests/check.pp
+++ b/tests/check.pp
@@ -3,3 +3,7 @@ include monit
 monit::check { 'ntp':
   source => "puppet:///modules/${module_name}/ntp",
 }
+
+monit::check { 'fake':
+  content => 'fake content for the fake service check',
+}


### PR DESCRIPTION
We can now give content instead of source to monit::check